### PR TITLE
API implemented for fetching variables by process diffinition and instance key

### DIFF
--- a/src/main/java/org/mifos/ops/zeebe/camel/routes/OperationsRouteBuilder.java
+++ b/src/main/java/org/mifos/ops/zeebe/camel/routes/OperationsRouteBuilder.java
@@ -55,7 +55,7 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
          *   "originDate": "1634027804733"
          * }
          */
-        from(String.format("rest:get:/channel/process/variable/{%s}/{%s}", PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY))
+        from(String.format("rest:get:/channel/process/{%s}/task/{%s}/variable/", PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY))
                 .id("get-process-variable")
                 .log(LoggingLevel.INFO, "## Fetch process variable")
                 .process(exchange -> {

--- a/src/main/java/org/mifos/ops/zeebe/zeebe/ZeebeVariables.java
+++ b/src/main/java/org/mifos/ops/zeebe/zeebe/ZeebeVariables.java
@@ -7,4 +7,6 @@ public class ZeebeVariables {
 
     public static final String TRANSACTION_ID = "transactionId";
     public static final String BPMN_PROCESS_ID = "BPMN_PROCESS_ID";
+    public static final String PROCESS_DEFINITION_KEY = "PROCESS_DEFINITION_KEY";
+    public static final String PROCESS_INSTANCE_KEY = "PROCESS_INSTANCE_KEY";
 }


### PR DESCRIPTION
Implemented API for fetching variable by process definition key and instance key.

*Sample request*
```localhost:5000/channel/process/variable/2251799813685998/2251799815797845```

*Sample response*
```JSON
{
  "note": "null",
  "fileName": "\"1634027804607_1634027804607request_temp.csv\"",
  "requestId": "\"00bbb830399242c1bd813c3b7cab6232\"",
  "batchId": "\"024ca343-caf5-434f-b428-55998be9b58a\"",
  "originDate": "1634027804733"
}
```