### PR TITLE
Elastic search endpoint config added in application properties

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,13 @@ zeebe:
   broker:
     contactpoint: "localhost:26500"
 
+spring:
+  data:
+    elasticsearch:
+      client:
+        reactive:
+          endpoints: "localhost:9200"
+
 logging:
   level:
     ROOT: ERROR


### PR DESCRIPTION
After merging this PR we have to override `spring_data_elasticsearch_client_reactive_endpoints` in helm