### PR TITLE
Upgrade Zeebe to 8.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'org.apache.camel:camel-bean-validator:3.4.0'
     implementation 'org.apache.camel:camel-undertow:3.4.0'
     implementation 'org.apache.camel.springboot:camel-jackson-starter:3.4.0'
-    implementation 'io.camunda:zeebe-client-java:1.1.0'
+    implementation 'io.camunda:zeebe-client-java:8.1.1'
     implementation 'io.netty:netty-bom:4.1.65.Final'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1'
     implementation 'org.json:json:20211205'

--- a/src/main/java/org/mifos/ops/zeebe/camel/routes/OperationsRouteBuilder.java
+++ b/src/main/java/org/mifos/ops/zeebe/camel/routes/OperationsRouteBuilder.java
@@ -451,9 +451,9 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
                             .send()
                             .join();
                     JSONObject res = new JSONObject();
-                    res.put("BpmnProcessId", job.getBpmnProcessId());
-                    res.put("ProcessInstanceKey", job.getProcessInstanceKey());
-                    res.put("ProcessDefinitionKey", job.getProcessDefinitionKey());
+                    res.put("bpmnProcessId", job.getBpmnProcessId());
+                    res.put("processInstanceKey", job.getProcessInstanceKey());
+                    res.put("processDefinitionKey", job.getProcessDefinitionKey());
                     e.getMessage().setBody(res.toString());
                 });
 

--- a/src/main/java/org/mifos/ops/zeebe/camel/routes/OperationsRouteBuilder.java
+++ b/src/main/java/org/mifos/ops/zeebe/camel/routes/OperationsRouteBuilder.java
@@ -2,6 +2,7 @@ package org.mifos.ops.zeebe.camel.routes;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.Definitions;
@@ -443,13 +444,17 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
                     e.getMessage().setBody(e.getIn().getHeader(BPMN_PROCESS_ID, String.class));
 
 
-                    zeebeClient.newCreateInstanceCommand()
+                    ProcessInstanceEvent job = zeebeClient.newCreateInstanceCommand()
                             .bpmnProcessId(e.getIn().getHeader(BPMN_PROCESS_ID, String.class))
                             .latestVersion()
                             .variables(variables)
                             .send()
                             .join();
-
+                    JSONObject res = new JSONObject();
+                    res.put("BpmnProcessId", job.getBpmnProcessId());
+                    res.put("ProcessInstanceKey", job.getProcessInstanceKey());
+                    res.put("ProcessDefinitionKey", job.getProcessDefinitionKey());
+                    e.getMessage().setBody(res.toString());
                 });
 
         /**


### PR DESCRIPTION
## Description

This PR upgrades the zeebe client version to 8.1.1 and also includes changes related to the start a workflow API.

Previous response:

- BPMN process ID

New response:

- Process Instance Key
- Process Definition Key
- BPMN Process ID

Sample response for zeebetest BPMN
`{
    "processInstanceKey": 2251799814754659,
    "processDefinitionKey": 2251799814252897,
    "bpmnProcessId": "zeebetest"
}`

[GOV-449](https://mifosforge.jira.com/browse/GOV-449)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing


[GOV-449]: https://mifosforge.jira.com/browse/GOV-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ