### PR TITLE
[PHEE-499] Worker DFSPIDs in inbound-ams-mifo.bpmn workflow is not changing while uploading

### DIFF
--- a/src/main/java/org/mifos/ops/zeebe/camel/routes/OperationsRouteBuilder.java
+++ b/src/main/java/org/mifos/ops/zeebe/camel/routes/OperationsRouteBuilder.java
@@ -102,11 +102,29 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
             processElement.setAttribute("name", tenantSpecificId);
             String fp = String.format("upload/%s.bpmn", tenantSpecificId);
             Bpmn.writeModelToFile(new File(fp), tenantSpecificInstance);
+            formatBpmnWorker(fp,tenant);
             Bpmn.validateModel(tenantSpecificInstance);
             uploadingFilePath.add(fp);
             logger.info("Done");
         }
         return uploadingFilePath;
+    }
+    private void formatBpmnWorker(String filePath, String tenant) throws IOException {
+        File fileToBeModified = new File(filePath);
+        String oldContent = "";
+        BufferedReader reader = new BufferedReader(new FileReader(fileToBeModified));
+        String line = reader.readLine();
+
+        while (line != null)
+        {
+            oldContent = oldContent + line + System.lineSeparator();
+            line = reader.readLine();
+        }
+        String newContent = oldContent.replaceAll("DFSPID", tenant);
+        FileWriter writer = new FileWriter(fileToBeModified);
+        writer.write(newContent);
+        reader.close();
+        writer.close();
     }
 
     @Override


### PR DESCRIPTION


## Description

[PHEE-499 Worker DFSPIDs in inbound-ams-mifo.bpmn workflow is not changing wh…](https://fynarfin.atlassian.net/browse/PHEE-499?atlOrigin=eyJpIjoiOTlhMmNmNDI5OGY4NDVkNTk2NTM4MzZkNzE1ZTgwZWQiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [x] Followed the PR title naming convention mentioned above.

- [x] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
